### PR TITLE
Replace master with main

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "tph_docs_bot",
   "version": "1.0.0",
   "description": "A bot made for TPH (The Programmers Hangout - discord.gg/programming) ",
-  "main": "index.js",
+  "main": "dist/bot.js",
   "scripts": {
     "tsc": "tsc",
     "test": "echo \"Error: no test specified\" && exit 1"
@@ -12,6 +12,7 @@
   "dependencies": {
     "discord-akairo": "^8.1.0",
     "discord.js": "^12.5.1",
+    "discord.js-docs": "BenjammingKirby/discord.js-docs#types",
     "dotenv": "^8.2.0",
     "pm2": "^4.5.1"
   },

--- a/src/commands/docs/djs.ts
+++ b/src/commands/docs/djs.ts
@@ -1,8 +1,6 @@
-import { Message } from "discord.js";
+import type { Message } from "discord.js";
 import { Command } from "discord-akairo";
-import fetch from "node-fetch";
-import { stringify } from "querystring";
-
+import Doc from "discord.js-docs";
 export default class DiscordCommand extends Command {
   public constructor() {
     super("djs-docs", {
@@ -27,7 +25,7 @@ export default class DiscordCommand extends Command {
         },
         {
           id: "branch",
-          flag: ["master", "stable"],
+          flag: ["main", "stable"],
           match: "flag",
           default: "stable",
         },
@@ -38,12 +36,13 @@ export default class DiscordCommand extends Command {
   public async exec(message: Message, { query, branch }: { query: string; branch: string }): Promise<Message | Message[]> {
     const str = query.split(" ");
 
-    const source = branch ? "stable" : "master";
-
-    //src and q being the params accepted by the API
-    const queryString = stringify({ src: source, q: str.join(" ") });
-    const res = await fetch(`https://djsdocs.sorta.moe/v2/embed?${queryString}`);
-    const embedObj = await res.json();
+    const source = branch ? "stable" : "main";
+    const doc = await Doc.fetch(source, {force: true});
+    const resultEmbed = doc.resolveEmbed(str.join("#"));
+    if (!resultEmbed) return;
+    // For typings of djs' embeds
+    const timeStampDate = new Date(resultEmbed.timestamp);
+    const embedObj = {...resultEmbed, timestamp: timeStampDate} ;
 
     if (!embedObj) return;
 

--- a/src/commands/docs/djs.ts
+++ b/src/commands/docs/djs.ts
@@ -6,9 +6,9 @@ export default class DiscordCommand extends Command {
     super("djs-docs", {
       aliases: ["djs", "d.js", "djsdocs", "discordjs", "discord.js"],
       description: {
-        content: "Searches discord.js documentation for what it thinks you mean. Defaults to using the master branch",
+        content: "Searches discord.js documentation for what it thinks you mean. Defaults to using the main branch",
         usage: "<query> <optional branch>",
-        examples: ["Guild#Members", "Guild#Members master"],
+        examples: ["Guild#Members", "Guild#Members main"],
       },
       channel: "guild",
       clientPermissions: ["EMBED_LINKS"],

--- a/yarn.lock
+++ b/yarn.lock
@@ -592,6 +592,11 @@ commander@2.15.1:
   resolved "https://registry.yarnpkg.com/commander/-/commander-2.15.1.tgz#df46e867d0fc2aec66a34662b406a9ccafff5b0f"
   integrity sha512-VlfT9F3V0v+jr4yxPc5gg9s62/fIVWsd2Bk2iD435um1NlGMYdVCq+MjcXnhYq2icNOizHr1kK+5TI6H0Hy0ag==
 
+common-tags@^1.8.0:
+  version "1.8.0"
+  resolved "https://registry.yarnpkg.com/common-tags/-/common-tags-1.8.0.tgz#8e3153e542d4a39e9b10554434afaaf98956a937"
+  integrity sha512-6P6g0uetGpW/sdyUy/iQQCbFF0kWVMSIVSyYz7Zgjcgh8mgw8PQzDNZeyZ5DQ2gM7LBoZPHmnjz8rUthkBG5tw==
+
 concat-map@0.0.1:
   version "0.0.1"
   resolved "https://registry.yarnpkg.com/concat-map/-/concat-map-0.0.1.tgz#d8a96bd77fd68df7793a73036a3ba0d5405d477b"
@@ -736,6 +741,14 @@ discord-akairo@^8.1.0:
   version "8.1.0"
   resolved "https://registry.yarnpkg.com/discord-akairo/-/discord-akairo-8.1.0.tgz#9f3d910e12c197d40d3522a3a93679e2a746a6ca"
   integrity sha512-INWYmHo6NgyYx1ZKGSCmgznVfvkXpWGj4fGCGjO8IPkZ06Bidb9YKr4rXy2lwG0kprCjvqY0qbbhcw6N050abQ==
+
+discord.js-docs@BenjammingKirby/discord.js-docs#types:
+  version "0.1.2"
+  resolved "https://codeload.github.com/BenjammingKirby/discord.js-docs/tar.gz/f8a89e4f2ae9adff2104a79e501e59aadc8e9dbe"
+  dependencies:
+    common-tags "^1.8.0"
+    fuse.js "^3.4.6"
+    node-fetch "^2.6.0"
 
 discord.js@^12.5.1:
   version "12.5.1"
@@ -1096,6 +1109,11 @@ functional-red-black-tree@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/functional-red-black-tree/-/functional-red-black-tree-1.0.1.tgz#1b0ab3bd553b2a0d6399d29c0e3ea0b252078327"
   integrity sha1-GwqzvVU7Kg1jmdKcDj6gslIHgyc=
+
+fuse.js@^3.4.6:
+  version "3.6.1"
+  resolved "https://registry.yarnpkg.com/fuse.js/-/fuse.js-3.6.1.tgz#7de85fdd6e1b3377c23ce010892656385fd9b10c"
+  integrity sha512-hT9yh/tiinkmirKrlv4KWOjztdoZo1mx9Qh4KvWqC7isoXwdUY3PNWUxceF4/qO9R6riA2C29jdTOeQOIROjgw==
 
 get-stdin@^4.0.1:
   version "4.0.1"
@@ -1543,7 +1561,7 @@ netmask@^1.0.6:
   resolved "https://registry.yarnpkg.com/netmask/-/netmask-1.0.6.tgz#20297e89d86f6f6400f250d9f4f6b4c1945fcd35"
   integrity sha1-ICl+idhvb2QA8lDZ9Pa0wZRfzTU=
 
-node-fetch@^2.6.1:
+node-fetch@^2.6.0, node-fetch@^2.6.1:
   version "2.6.1"
   resolved "https://registry.yarnpkg.com/node-fetch/-/node-fetch-2.6.1.tgz#045bd323631f76ed2e2b55573394416b639a0052"
   integrity sha512-V4aYg89jEoVRxRb2fJdAg8FHvI7cEyYdVAh94HH0UIK8oJxUfkjlDQN9RbMx+bEjP7+ggMiFRprSti032Oipxw==


### PR DESCRIPTION
This PR removes the outdated API used to get djs docs and now adds the capability to get the main branch as opposed to the now deleted master branch of discord.js

The way this achieves that is by adding an npm package called [discord.js-docs](https://www.npmjs.com/package/discord.js-docs)
fixes #6 