### PR TITLE
Replace fork to discord.js-docs

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
   "dependencies": {
     "discord-akairo": "^8.1.0",
     "discord.js": "^12.5.1",
-    "discord.js-docs": "BenjammingKirby/discord.js-docs#types",
+    "discord.js-docs": "^0.1.2",
     "dotenv": "^8.2.0",
     "pm2": "^4.5.1"
   },

--- a/src/commands/docs/djs.ts
+++ b/src/commands/docs/djs.ts
@@ -1,6 +1,7 @@
 import type { Message } from "discord.js";
 import { Command } from "discord-akairo";
 import Doc from "discord.js-docs";
+import sources = require("../../sources.json");
 export default class DiscordCommand extends Command {
   public constructor() {
     super("djs-docs", {
@@ -36,7 +37,7 @@ export default class DiscordCommand extends Command {
   public async exec(message: Message, { query, branch }: { query: string; branch: string }): Promise<Message | Message[]> {
     const str = query.split(" ");
 
-    const source = branch ? "stable" : "main";
+    const source = branch ? "stable" : sources["main"];
     const doc = await Doc.fetch(source, {force: true});
     const resultEmbed = doc.resolveEmbed(str.join("#"));
     if (!resultEmbed) return;

--- a/src/sources.json
+++ b/src/sources.json
@@ -1,0 +1,13 @@
+{
+    "stable": "https://raw.githubusercontent.com/discordjs/discord.js/docs/stable.json",
+    "main": "https://raw.githubusercontent.com/discordjs/discord.js/docs/main.json",
+    "commando": "https://raw.githubusercontent.com/discordjs/commando/docs/master.json",
+    "rpc": "https://raw.githubusercontent.com/discordjs/rpc/docs/master.json",
+    "akairo": "https://raw.githubusercontent.com/discord-akairo/discord-akairo/docs/8.1.0.json",
+    "collection": "https://raw.githubusercontent.com/discordjs/collection/docs/stable.json",
+    "collection-main": "https://raw.githubusercontent.com/discordjs/collection/docs/main.json",
+    "builders":"https://raw.githubusercontent.com/discordjs/builders/docs/stable.json",
+    "builders-main":"https://raw.githubusercontent.com/discordjs/builders/docs/main.json",
+    "voice":"https://raw.githubusercontent.com/discordjs/voice/docs/stable.json",
+    "voice-main":"https://raw.githubusercontent.com/discordjs/voice/docs/main.json"
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -742,12 +742,13 @@ discord-akairo@^8.1.0:
   resolved "https://registry.yarnpkg.com/discord-akairo/-/discord-akairo-8.1.0.tgz#9f3d910e12c197d40d3522a3a93679e2a746a6ca"
   integrity sha512-INWYmHo6NgyYx1ZKGSCmgznVfvkXpWGj4fGCGjO8IPkZ06Bidb9YKr4rXy2lwG0kprCjvqY0qbbhcw6N050abQ==
 
-discord.js-docs@BenjammingKirby/discord.js-docs#types:
+discord.js-docs@^0.1.2:
   version "0.1.2"
-  resolved "https://codeload.github.com/BenjammingKirby/discord.js-docs/tar.gz/f8a89e4f2ae9adff2104a79e501e59aadc8e9dbe"
+  resolved "https://registry.yarnpkg.com/discord.js-docs/-/discord.js-docs-0.1.2.tgz#65941b3d037346cec220d1b5e0ec8e46aa62697e"
+  integrity sha512-DrDOJD3odnmGJE8HyVaspAYiUN51LotzqIH/tNq9PydZva+wceVM5dijEBI+g/0hSl1/CQKTIgN3z0dIcMv0CQ==
   dependencies:
     common-tags "^1.8.0"
-    fuse.js "^3.4.6"
+    fuse.js "^3.2.1"
     node-fetch "^2.6.0"
 
 discord.js@^12.5.1:
@@ -1110,7 +1111,7 @@ functional-red-black-tree@^1.0.1:
   resolved "https://registry.yarnpkg.com/functional-red-black-tree/-/functional-red-black-tree-1.0.1.tgz#1b0ab3bd553b2a0d6399d29c0e3ea0b252078327"
   integrity sha1-GwqzvVU7Kg1jmdKcDj6gslIHgyc=
 
-fuse.js@^3.4.6:
+fuse.js@^3.2.1:
   version "3.6.1"
   resolved "https://registry.yarnpkg.com/fuse.js/-/fuse.js-3.6.1.tgz#7de85fdd6e1b3377c23ce010892656385fd9b10c"
   integrity sha512-hT9yh/tiinkmirKrlv4KWOjztdoZo1mx9Qh4KvWqC7isoXwdUY3PNWUxceF4/qO9R6riA2C29jdTOeQOIROjgw==


### PR DESCRIPTION
since with the current setting of docker, installing a package from a fork isn't possible, instead of changing the docker configuration i've reverted to simply using the actual npm package discord.js-docs
since they still link to masters on the package, i've had to add a new sources.json 