### PR TITLE
Fix DJS Docs URLs

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1210,8 +1210,8 @@
       }
     },
     "node_modules/discord.js-docs": {
-      "version": "0.1.2",
-      "resolved": "git+ssh://git@github.com/BenjammingKirby/discord.js-docs.git#82ab2d35299ef2077ee90ff9a622f4efb6b6bb8f",
+      "version": "0.1.3",
+      "resolved": "git+ssh://git@github.com/BenjammingKirby/discord.js-docs.git#0273aa3b6637b276969620d7193c34204fa18f9f",
       "license": "MIT",
       "dependencies": {
         "@types/common-tags": "^1.8.1",
@@ -4416,7 +4416,7 @@
       }
     },
     "discord.js-docs": {
-      "version": "git+ssh://git@github.com/BenjammingKirby/discord.js-docs.git#82ab2d35299ef2077ee90ff9a622f4efb6b6bb8f",
+      "version": "git+ssh://git@github.com/BenjammingKirby/discord.js-docs.git#0273aa3b6637b276969620d7193c34204fa18f9f",
       "from": "discord.js-docs@BenjammingKirby/discord.js-docs#typescriptRewrite",
       "requires": {
         "@types/common-tags": "^1.8.1",


### PR DESCRIPTION
The URLs that link to the discord.js.org are invalid now due to the current changes 

this PR updates discord.js-docs where this issue is fixed 