### PR TITLE
Support 25 options and autocompletion for other djs sources

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -4,41 +4,26 @@
         "es2021": true,
         "node": true
     },
-    "extends": [
-        "eslint:recommended",
-        "plugin:@typescript-eslint/recommended"
-    ],
+    "extends": ["eslint:recommended", "plugin:@typescript-eslint/recommended"],
     "parser": "@typescript-eslint/parser",
     "parserOptions": {
         "ecmaVersion": 12
     },
-    "plugins": [
-        "@typescript-eslint"
-    ],
+    "plugins": ["@typescript-eslint"],
     "rules": {
-        "indent": [
-            "error",
-            4,  { "SwitchCase": 1 }
-        ],
-        "linebreak-style": [
-            "error",
-            "unix"
-        ],
-        "quotes": [
-            "error",
-            "double"
-        ],
-        "semi": [
-            "error",
-            "always"
-        ],
-        "strict" :"error",
-        "no-var":"error",
-        "no-console": ["warn", {"allow": ["info", "error", "warn"]}],
-        "array-callback-return":"error",
-        "yoda":"error",
-        "@typescript-eslint/no-unused-vars": ["error", {"varsIgnorePattern": "^_", "argsIgnorePattern": "^_"}],
+        "indent": ["off"],
+        "@typescript-eslint/indent": ["error", 4, { "SwitchCase": 1 }],
+        "linebreak-style": ["error", "unix"],
+        "quotes": ["error", "double"],
+        "semi": ["error", "always"],
+        "strict": "error",
+        "no-var": "error",
+        "no-console": ["warn", { "allow": ["info", "error", "warn"] }],
+        "array-callback-return": "error",
+        "yoda": "error",
+        "@typescript-eslint/no-unused-vars": ["error", { "varsIgnorePattern": "^_", "argsIgnorePattern": "^_" }],
         "@typescript-eslint/ban-ts-comment": "off",
-        "@typescript-eslint/no-non-null-assertion": "off"
+        "@typescript-eslint/no-non-null-assertion": "off",
+        "prefer-const": ["error", { "destructuring": "all" }]
     }
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1238,7 +1238,7 @@
     },
     "node_modules/discord.js-docs": {
       "version": "0.1.3",
-      "resolved": "git+ssh://git@github.com/BenjammingKirby/discord.js-docs.git#0273aa3b6637b276969620d7193c34204fa18f9f",
+      "resolved": "git+ssh://git@github.com/BenjammingKirby/discord.js-docs.git#973b99fd221270814fd26c6e3c9cb0eb74a90c50",
       "license": "MIT",
       "dependencies": {
         "@types/common-tags": "^1.8.1",
@@ -2366,14 +2366,22 @@
       }
     },
     "node_modules/node-fetch": {
-      "version": "2.6.6",
-      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.6.tgz",
-      "integrity": "sha512-Z8/6vRlTUChSdIgMa51jxQ4lrw/Jy5SOW10ObaA47/RElsAN2c5Pn8bTgFGWn/ibwzXTE8qwr1Yzx28vsecXEA==",
+      "version": "2.6.7",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.7.tgz",
+      "integrity": "sha512-ZjMPFEfVx5j+y2yF35Kzx5sF7kDzxuDj6ziH4FFbOp87zKDZNx8yExJIb05OGF4Nlt9IHFIMBkRl41VdvcNdbQ==",
       "dependencies": {
         "whatwg-url": "^5.0.0"
       },
       "engines": {
         "node": "4.x || >=6.0.0"
+      },
+      "peerDependencies": {
+        "encoding": "^0.1.0"
+      },
+      "peerDependenciesMeta": {
+        "encoding": {
+          "optional": true
+        }
       }
     },
     "node_modules/normalize-path": {
@@ -4455,7 +4463,7 @@
       }
     },
     "discord.js-docs": {
-      "version": "git+ssh://git@github.com/BenjammingKirby/discord.js-docs.git#0273aa3b6637b276969620d7193c34204fa18f9f",
+      "version": "git+ssh://git@github.com/BenjammingKirby/discord.js-docs.git#973b99fd221270814fd26c6e3c9cb0eb74a90c50",
       "from": "discord.js-docs@github:BenjammingKirby/discord.js-docs#typescriptRewrite",
       "requires": {
         "@types/common-tags": "^1.8.1",
@@ -5313,9 +5321,9 @@
       "integrity": "sha512-dBpDMdxv9Irdq66304OLfEmQ9tbNRFnFTuZiLo+bD+r332bBmMJ8GBLXklIXXgxd3+v9+KUnZaUR5PJMa75Gsg=="
     },
     "node-fetch": {
-      "version": "2.6.6",
-      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.6.tgz",
-      "integrity": "sha512-Z8/6vRlTUChSdIgMa51jxQ4lrw/Jy5SOW10ObaA47/RElsAN2c5Pn8bTgFGWn/ibwzXTE8qwr1Yzx28vsecXEA==",
+      "version": "2.6.7",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.7.tgz",
+      "integrity": "sha512-ZjMPFEfVx5j+y2yF35Kzx5sF7kDzxuDj6ziH4FFbOp87zKDZNx8yExJIb05OGF4Nlt9IHFIMBkRl41VdvcNdbQ==",
       "requires": {
         "whatwg-url": "^5.0.0"
       }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1238,7 +1238,7 @@
     },
     "node_modules/discord.js-docs": {
       "version": "0.1.3",
-      "resolved": "git+ssh://git@github.com/BenjammingKirby/discord.js-docs.git#973b99fd221270814fd26c6e3c9cb0eb74a90c50",
+      "resolved": "git+ssh://git@github.com/BenjammingKirby/discord.js-docs.git#636e83ea510b68a5fd2a46724395ecdc4bd02e1a",
       "license": "MIT",
       "dependencies": {
         "@types/common-tags": "^1.8.1",
@@ -4463,8 +4463,8 @@
       }
     },
     "discord.js-docs": {
-      "version": "git+ssh://git@github.com/BenjammingKirby/discord.js-docs.git#973b99fd221270814fd26c6e3c9cb0eb74a90c50",
-      "from": "discord.js-docs@github:BenjammingKirby/discord.js-docs#typescriptRewrite",
+      "version": "git+ssh://git@github.com/BenjammingKirby/discord.js-docs.git#636e83ea510b68a5fd2a46724395ecdc4bd02e1a",
+      "from": "discord.js-docs@BenjammingKirby/discord.js-docs#typescriptRewrite",
       "requires": {
         "@types/common-tags": "^1.8.1",
         "common-tags": "^1.8.0",

--- a/src/bot.ts
+++ b/src/bot.ts
@@ -3,6 +3,7 @@ import { Client, Collection, LimitedCollection } from "discord.js";
 import { MyContext } from "./interfaces";
 import { loadCommands, interactionCreateHandler } from "./handlers/InteractionCreateHandler";
 import { messageHandler } from "./handlers/MessageHandler";
+import { deleteButtonHandler } from "./utils/CommandUtils";
 
 (async function () {
     const context: MyContext = {
@@ -15,7 +16,7 @@ import { messageHandler } from "./handlers/MessageHandler";
             // For DMs, a partial channel object is received, in order to receive dms, CHANNEL partials must be activated
             partials: ["CHANNEL"],
             makeCache: (manager) => {
-                //! Disabling these caches will break djs funcitonality
+                //! Disabling these caches will break djs functionality
                 const unsupportedCaches = [
                     "GuildManager",
                     "ChannelManager",
@@ -38,6 +39,8 @@ import { messageHandler } from "./handlers/MessageHandler";
     };
     const docsBot = context.client;
     await loadCommands(context);
+    // Add delete button handler
+    context.commands.buttons.set("deletebtn", { custom_id: "deletebtn", run: deleteButtonHandler });
 
     docsBot.on("error", console.error);
     docsBot.on("warn", console.warn);

--- a/src/bot.ts
+++ b/src/bot.ts
@@ -28,7 +28,12 @@ import { messageHandler } from "./handlers/MessageHandler";
                 return new LimitedCollection({ maxSize: 0 });
             },
         }),
-        commands: new Collection(),
+        commands: {
+            autocompletes: new Collection(),
+            buttons: new Collection(),
+            selectMenus: new Collection(),
+            slashCommands: new Collection(),
+        },
         cooldownCounter: new Collection(),
     };
     const docsBot = context.client;

--- a/src/commands/docs/djs.ts
+++ b/src/commands/docs/djs.ts
@@ -2,96 +2,167 @@ import { Command } from "../../interfaces";
 import { SlashCommandBuilder } from "@discordjs/builders";
 import Doc, { sources } from "discord.js-docs";
 import { checkEmbedLimits } from "../../utils/EmbedUtils";
-import { deleteButton } from "../../utils/CommandUtils";
+import { deleteButton, deleteButtonHandler } from "../../utils/CommandUtils";
 import { MessageActionRow, MessageSelectMenu } from "discord.js";
 import type { APIEmbed } from "discord-api-types";
 
 const supportedBranches = Object.keys(sources).map((branch) => [capitalize(branch), branch] as [string, string]);
 
 const command: Command = {
-    data: new SlashCommandBuilder()
-        .setName("djs")
-        .setDescription("Search discord.js documentations, supports builders, voice, collection and rpc documentations")
-        .addStringOption((option) =>
-            option
-                .setName("query")
-                .setDescription("Enter the phrase you'd like to search for, e.g: client#isready")
-                .setRequired(true)
-                .setAutocomplete(true),
-        )
-        .addStringOption((option) =>
-            option
-                .setName("source")
-                .setDescription("Select which branch/repository to get documentation off of (Default: stable)")
-                .addChoices(supportedBranches)
-                .setRequired(false),
-        )
-        .addBooleanOption((option) =>
-            option
-                .setName("private")
-                .setDescription("Whether or not to search private elements (default false)")
-                .setRequired(false),
-        ),
-    async execute(interaction) {
-        const deleteButtonRow = new MessageActionRow().addComponents([deleteButton(interaction.user.id)]);
-        const query = interaction.options.getString("query");
-        // The Default source should be stable
-        const source: keyof typeof sources =
-            (interaction.options.getString("source") as keyof typeof sources) || "stable";
-        // Whether to include private elements on the search results, by default false, shows private elements if the search returns an exact result;
-        const searchPrivate = interaction.options.getBoolean("private") || false;
-        const doc = await Doc.fetch(source, { force: true }).catch(console.error);
+    slashCommand: {
+        data: new SlashCommandBuilder()
+            .setName("djs")
+            .setDescription(
+                "Search discord.js documentations, supports builders, voice, collection and rpc documentations",
+            )
+            .addStringOption((option) =>
+                option
+                    .setName("query")
+                    .setDescription("Enter the phrase you'd like to search for, e.g: client#isready")
+                    .setRequired(true)
+                    .setAutocomplete(true),
+            )
+            .addStringOption((option) =>
+                option
+                    .setName("source")
+                    .setDescription("Select which branch/repository to get documentation off of (Default: stable)")
+                    .addChoices(supportedBranches)
+                    .setRequired(false),
+            )
+            .addBooleanOption((option) =>
+                option
+                    .setName("private")
+                    .setDescription("Whether or not to search private elements (default false)")
+                    .setRequired(false),
+            ),
+        async run(interaction) {
+            const deleteButtonRow = new MessageActionRow().addComponents([deleteButton(interaction.user.id)]);
+            const queryOption = interaction.options.getString("query");
+            const sourceOption = interaction.options.getString("source") as keyof typeof sources;
 
-        if (!doc) {
-            await interaction.editReply({ content: "Couldn't fetch docs" }).catch(console.error);
+            let { Source: source = "stable", Query: query } =
+                queryOption.match(/(?:(?<Source>[^/]*)\/)?(?<Query>(?:.|\s)*)/i)?.groups ?? {};
+            // The Default source should be stable
+            if (!sources[source]) source = "stable";
+
+            if (sourceOption) source = sourceOption;
+            // Whether to include private elements on the search results, by default false, shows private elements if the search returns an exact result;
+            const searchPrivate = interaction.options.getBoolean("private") || false;
+            const doc = await Doc.fetch(source, { force: true }).catch(console.error);
+
+            if (!doc) {
+                await interaction.editReply({ content: "Couldn't fetch docs" }).catch(console.error);
+                return;
+            }
+            // const resultEmbed = doc.resolveEmbed(query, { excludePrivateElements: !searchPrivate });
+            const result = searchDJSDoc(doc, query, searchPrivate);
+            // If a result wasn't found
+            if (!result || (result as APIEmbed).description === "") {
+                const notFoundEmbed = doc.baseEmbed();
+                notFoundEmbed.description = "Didn't find any results for that query";
+
+                const timeStampDate = new Date(notFoundEmbed.timestamp);
+                // Satisfies the method's MessageEmbedOption type
+                const embedObj = { ...notFoundEmbed, timestamp: timeStampDate };
+
+                await interaction.editReply({ embeds: [embedObj] }).catch(console.error);
+                return;
+            } else if (Array.isArray(result)) {
+                // If there are multiple results, send a select menu from which the user can choose which one to send
+
+                const selectMenuRow = new MessageActionRow().addComponents(
+                    new MessageSelectMenu()
+                        .setCustomId(`djsselect/${source}/${searchPrivate}/${interaction.user.id}`)
+                        .addOptions(result)
+                        .setPlaceholder("Select documentation to send"),
+                );
+                await interaction
+                    .editReply({
+                        content: "Didn't find an exact match, please select one from below",
+                        components: [selectMenuRow],
+                    })
+                    .catch(console.error);
+                return;
+            }
+            const resultEmbed = result;
+            const timeStampDate = new Date(resultEmbed.timestamp);
+            const embedObj = { ...resultEmbed, timestamp: timeStampDate };
+
+            //! "checkEmbedLimits" does not support MessageEmbed objects due to the properties being null by default, use a raw embed object for this method
+            // Check if the embed exceeds any of the limits
+            if (!checkEmbedLimits([resultEmbed])) {
+                // The final field should be the View Source button
+                embedObj.fields = [embedObj.fields?.at(-1)];
+            }
+            await interaction.editReply({
+                content: "Sent documentations for " + (query.length >= 100 ? query.slice(0, 100) + "..." : query),
+            });
+            await interaction.followUp({ embeds: [embedObj], components: [deleteButtonRow] }).catch(console.error);
             return;
-        }
-        // const resultEmbed = doc.resolveEmbed(query, { excludePrivateElements: !searchPrivate });
-        const result = searchDJSDoc(doc, query, searchPrivate);
-        // If a result wasn't found
-        if (!result || (result as APIEmbed).description === "") {
-            const notFoundEmbed = doc.baseEmbed();
-            notFoundEmbed.description = "Didn't find any results for that query";
-
-            const timeStampDate = new Date(notFoundEmbed.timestamp);
-            // Satisfies the method's MessageEmbedOption type
-            const embedObj = { ...notFoundEmbed, timestamp: timeStampDate };
-
-            await interaction.editReply({ embeds: [embedObj] }).catch(console.error);
-            return;
-        } else if (Array.isArray(result)) {
-            // If there are multiple results, send a select menu from which the user can choose which one to send
-
-            const selectMenuRow = new MessageActionRow().addComponents(
-                new MessageSelectMenu()
-                    .setCustomId(`djsselect/${source}/${searchPrivate}/${interaction.user.id}`)
-                    .addOptions(result)
-                    .setPlaceholder("Select documentation to send"),
-            );
-            await interaction
-                .editReply({
-                    content: "Didn't find an exact match, please select one from below",
-                    components: [selectMenuRow],
-                })
-                .catch(console.error);
-            return;
-        }
-        const resultEmbed = result;
-        const timeStampDate = new Date(resultEmbed.timestamp);
-        const embedObj = { ...resultEmbed, timestamp: timeStampDate };
-
-        //! "checkEmbedLimits" does not support MessageEmbed objects due to the properties being null by default, use a raw embed object for this method
-        // Check if the embed exceeds any of the limits
-        if (!checkEmbedLimits([resultEmbed])) {
-            // The final field should be the View Source button
-            embedObj.fields = [embedObj.fields?.at(-1)];
-        }
-        await interaction.editReply({
-            content: "Sent documentations for " + (query.length >= 100 ? query.slice(0, 100) + "..." : query),
-        });
-        await interaction.followUp({ embeds: [embedObj], components: [deleteButtonRow] }).catch(console.error);
-        return;
+        },
     },
+    buttons: [{ custom_id: "deletebtn", run: deleteButtonHandler }],
+    selectMenus: [
+        {
+            custom_id: "djsselect",
+            async run(interaction) {
+                const selectedValue = interaction.values[0];
+                const [, source, searchPrivate, Initiator] = interaction.customId.split("/");
+                const deleteButtonRow = new MessageActionRow().addComponents([deleteButton(Initiator)]);
+
+                const doc = await Doc.fetch(source, { force: true });
+
+                const resultEmbed = searchDJSDoc(doc, selectedValue, searchPrivate === "true") as APIEmbed;
+
+                // Remove the menu and update the ephemeral message
+                await interaction
+                    .editReply({ content: "Sent documentations for " + selectedValue, components: [] })
+                    .catch(console.error);
+                // Send documentation
+                await interaction
+                    .followUp({ embeds: [resultEmbed], components: [deleteButtonRow] })
+                    .catch(console.error);
+            },
+        },
+    ],
+    autocomplete: [
+        {
+            focusedOption: "query",
+            async run(interaction, focusedOption) {
+                const focusedOptionValue = focusedOption.value as string;
+                let { Branch: branchOrProject = "stable", Query: query } =
+                    focusedOptionValue.match(/(?:(?<Branch>[^/]*)\/)?(?<Query>(?:.|\s)*)/i)?.groups ?? {};
+                if (!sources[branchOrProject]) branchOrProject = "stable";
+
+                const doc = await Doc.fetch(branchOrProject, { force: false });
+                const singleElement = doc.get(...query.split(/\.|#/));
+                if (singleElement) {
+                    await interaction
+                        .respond([
+                            {
+                                name: singleElement.formattedName,
+                                value: branchOrProject + "/" + singleElement.formattedName,
+                            },
+                        ])
+                        .catch(console.error);
+                    return;
+                }
+                const searchResults = doc.search(query, { excludePrivateElements: false });
+                if (!searchResults) {
+                    await interaction.respond([]).catch(console.error);
+                    return;
+                }
+                await interaction
+                    .respond(
+                        searchResults.map((elem) => ({
+                            name: elem.formattedName,
+                            value: branchOrProject + "/" + elem.formattedName,
+                        })),
+                    )
+                    .catch(console.error);
+            },
+        },
+    ],
 };
 
 function capitalize(str: string) {
@@ -112,8 +183,9 @@ export function searchDJSDoc(doc: Doc, query: string, searchPrivate?: boolean) {
     const searchResults = doc.search(query, options);
     if (!searchResults) return null;
     return searchResults.map((res) => {
+        const parsedDescription = res.description?.trim?.() ?? "No description provided";
         // Labels and values have a limit of 100 characters
-        const description = res.description.length >= 99 ? res.description.slice(0, 96) + "..." : res.description;
+        const description = parsedDescription.length >= 99 ? parsedDescription.slice(0, 96) + "..." : parsedDescription;
         return {
             label: res.formattedName,
             description,

--- a/src/handlers/InteractionCreateHandler.ts
+++ b/src/handlers/InteractionCreateHandler.ts
@@ -1,3 +1,5 @@
+import { commandCooldownCheck, commandPermissionCheck } from "../utils/CommandUtils";
+import glob from "glob";
 import type { Command, MyContext } from "../interfaces";
 import type {
     AutocompleteInteraction,
@@ -6,10 +8,6 @@ import type {
     Interaction,
     SelectMenuInteraction,
 } from "discord.js";
-
-import { commandCooldownCheck, commandPermissionCheck } from "../utils/CommandUtils";
-
-import glob from "glob";
 
 export async function interactionCreateHandler(context: MyContext, interaction: Interaction<"cached">) {
     try {
@@ -80,7 +78,8 @@ async function commandInteractionHandler(context: MyContext, interaction: Comman
     }
 }
 async function buttonInteractionHandler(context: MyContext, interaction: ButtonInteraction<"cached">) {
-    const button = context.commands.buttons.find((but) => interaction.customId.startsWith(but.custom_id));
+    const buttonId = interaction.customId.split("/")[0];
+    const button = context.commands.buttons.get(buttonId);
     if (button) {
         await button.run(interaction, context).catch(console.error);
         return;
@@ -93,9 +92,8 @@ async function buttonInteractionHandler(context: MyContext, interaction: ButtonI
 async function selectMenuInteractionHandler(context: MyContext, interaction: SelectMenuInteraction<"cached">) {
     await interaction.deferUpdate().catch(console.error);
 
-    const menu = context.commands.selectMenus.find((selectmenu) =>
-        interaction.customId.startsWith(selectmenu.custom_id),
-    );
+    const menuId = interaction.customId.split("/")[0];
+    const menu = context.commands.selectMenus.get(menuId);
     if (menu) {
         await menu.run(interaction, context).catch(console.error);
         return;

--- a/src/handlers/InteractionCreateHandler.ts
+++ b/src/handlers/InteractionCreateHandler.ts
@@ -4,18 +4,12 @@ import type {
     ButtonInteraction,
     CommandInteraction,
     Interaction,
-    Message,
     SelectMenuInteraction,
 } from "discord.js";
-import type { APIEmbed } from "discord-api-types";
 
-import { commandCooldownCheck, commandPermissionCheck, deleteButton } from "../utils/CommandUtils";
-import { getSingleMDNSearchResults, getSources } from "../commands/docs/mdn";
-import { searchDJSDoc } from "../commands/docs/djs";
-import { MessageActionRow } from "discord.js";
+import { commandCooldownCheck, commandPermissionCheck } from "../utils/CommandUtils";
 
 import glob from "glob";
-import Doc from "discord.js-docs";
 
 export async function interactionCreateHandler(context: MyContext, interaction: Interaction<"cached">) {
     try {
@@ -50,7 +44,18 @@ export function loadCommands(context: MyContext) {
                         return {};
                     });
                     if (!myCommandFile) return;
-                    context.commands.set(myCommandFile.data.name, myCommandFile);
+                    const { autocomplete, buttons, selectMenus, slashCommand } = myCommandFile;
+                    autocomplete?.forEach((autocom) =>
+                        context.commands.autocompletes.set(
+                            myCommandFile.slashCommand?.data.name + "/" + autocom.focusedOption,
+                            autocom,
+                        ),
+                    );
+                    buttons?.forEach((button) => context.commands.buttons.set(button.custom_id, button));
+                    selectMenus?.forEach((selectMenu) =>
+                        context.commands.selectMenus.set(selectMenu.custom_id, selectMenu),
+                    );
+                    slashCommand && context.commands.slashCommands.set(slashCommand.data.name, slashCommand);
                 }),
             );
             resolve(undefined);
@@ -59,14 +64,13 @@ export function loadCommands(context: MyContext) {
 }
 async function commandInteractionHandler(context: MyContext, interaction: CommandInteraction) {
     await interaction.deferReply({ ephemeral: true }).catch(console.error);
-
-    const command = context.commands.get(interaction.commandName);
+    const command = context.commands.slashCommands.get(interaction.commandName);
     if (!command) return interaction.editReply({ content: "Command not found" }).catch(console.error);
 
     if (commandPermissionCheck(interaction, command)) return;
     if (commandCooldownCheck(interaction, command, context)) return;
     try {
-        await command.execute(interaction, context);
+        await command.run(interaction, context);
     } catch (e) {
         console.error(e);
         const errorMessage = "An error has occurred";
@@ -75,97 +79,35 @@ async function commandInteractionHandler(context: MyContext, interaction: Comman
         }).catch(console.error);
     }
 }
-async function selectMenuInteractionHandler(context: MyContext, interaction: SelectMenuInteraction) {
-    await interaction.deferUpdate().catch(console.error);
-    const CommandName = interaction.customId.split("/")[0];
-    switch (CommandName) {
-        case "mdnselect": {
-            const Initiator = interaction.customId.split("/")[1];
-            const deleteButtonRow = new MessageActionRow().addComponents([deleteButton(Initiator)]);
-            const selectedValue = interaction.values[0];
-            const resultEmbed = await getSingleMDNSearchResults(selectedValue);
-
-            // Remove the menu and update the ephemeral message
-            await interaction
-                .editReply({ content: "Sent documentations for " + selectedValue, components: [] })
-                .catch(console.error);
-            // Send documentation
-            await interaction.followUp({ embeds: [resultEmbed], components: [deleteButtonRow] }).catch(console.error);
-            break;
-        }
-
-        case "djsselect": {
-            const selectedValue = interaction.values[0];
-            const [, source, searchPrivate, Initiator] = interaction.customId.split("/");
-            const deleteButtonRow = new MessageActionRow().addComponents([deleteButton(Initiator)]);
-
-            const doc = await Doc.fetch(source, { force: true });
-
-            const resultEmbed = searchDJSDoc(doc, selectedValue, searchPrivate === "true") as APIEmbed;
-
-            // Remove the menu and update the ephemeral message
-            await interaction
-                .editReply({ content: "Sent documentations for " + selectedValue, components: [] })
-                .catch(console.error);
-            // Send documentation
-            await interaction.followUp({ embeds: [resultEmbed], components: [deleteButtonRow] }).catch(console.error);
-            break;
-        }
-        default: {
-            interaction.editReply({ content: "Unknown menu" }).catch(console.error);
-        }
-    }
-}
 async function buttonInteractionHandler(context: MyContext, interaction: ButtonInteraction<"cached">) {
-    // The delete button
-    if (interaction.customId.startsWith("deletebtn")) {
-        const commandInitiatorId = interaction.customId.replace("deletebtn/", "");
-        // If the button clicker is the command initiator
-        if (interaction.user.id === commandInitiatorId) {
-            (interaction.message as Message).delete().catch(console.error);
-        } else
-            interaction
-                .reply({
-                    content: "Only the command initiator is allowed to delete this message",
-                    ephemeral: true,
-                })
-                .catch(console.error);
+    const button = context.commands.buttons.find((but) => interaction.customId.startsWith(but.custom_id));
+    if (button) {
+        await button.run(interaction, context).catch(console.error);
+        return;
     }
+    await interaction[interaction.replied ? "editReply" : "reply"]?.({
+        content: "Unknown Button",
+        ephemeral: true,
+    }).catch(console.error);
+}
+async function selectMenuInteractionHandler(context: MyContext, interaction: SelectMenuInteraction<"cached">) {
+    await interaction.deferUpdate().catch(console.error);
+
+    const menu = context.commands.selectMenus.find((selectmenu) =>
+        interaction.customId.startsWith(selectmenu.custom_id),
+    );
+    if (menu) {
+        await menu.run(interaction, context).catch(console.error);
+        return;
+    }
+    await interaction[interaction.replied ? "editReply" : "reply"]?.({
+        content: "Unknown menu",
+        ephemeral: true,
+    }).catch(console.error);
 }
 
-async function autocompleteInteractionHandler(context: MyContext, interaction: AutocompleteInteraction) {
-    switch (interaction.commandName) {
-        case "djs": {
-            // Check the cache, the command will force fetch anyway
-            const doc = await Doc.fetch("stable", { force: false });
-            const query = interaction.options.getFocused() as string;
-            const singleElement = doc.get(...query.split(/\.|#/));
-            if (singleElement) {
-                await interaction
-                    .respond([{ name: singleElement.formattedName, value: singleElement.formattedName }])
-                    .catch(console.error);
-                return;
-            }
-            const searchResults = doc.search(query, { excludePrivateElements: false });
-            if (!searchResults) {
-                await interaction.respond([]).catch(console.error);
-                return;
-            }
-            await interaction
-                .respond(searchResults.map((elem) => ({ name: elem.formattedName, value: elem.formattedName })))
-                .catch(console.error);
-            break;
-        }
-        case "mdn": {
-            const query = interaction.options.getFocused() as string;
-
-            const { index, sitemap } = await getSources();
-            const search = index.search(query, { limit: 10 }).map((id) => {
-                const val = sitemap[<number>id].loc;
-                const parsed = val.length >= 99 ? val.split("/").slice(-2).join("/") : val;
-                return { name: parsed, value: parsed };
-            });
-            await interaction.respond(search).catch(console.error);
-        }
-    }
+async function autocompleteInteractionHandler(context: MyContext, interaction: AutocompleteInteraction<"cached">) {
+    const focusedOption = interaction.options.getFocused(true);
+    const autocom = context.commands.autocompletes.get(interaction.commandName + "/" + focusedOption.name);
+    if (autocom) await autocom.run(interaction, focusedOption, context).catch(console.error);
 }

--- a/src/handlers/RegisterCommands.ts
+++ b/src/handlers/RegisterCommands.ts
@@ -8,18 +8,15 @@ const {
     GUILDID: guildId,
     TOKEN: token,
     /**
-   * REGISTER_MODE should be either "GUILD", "GUILD_RESET" or "GLOBAL"
-   * GLOBAL globally registers commands,
-   * GUILD registers on the provided GUILDID's guild
-   */
+     * REGISTER_MODE should be either "GUILD", "GUILD_RESET" or "GLOBAL"
+     * GLOBAL globally registers commands,
+     * GUILD registers on the provided GUILDID's guild
+     */
     REGISTER_MODE: registerMode = "GLOBAL",
 } = process.env;
 
 // Check if the environment variables were provided
-if (!applicationId)
-    throw new Error(
-        "Please make sure the bot's application ID is mentioned on \"APPLICATIONID\""
-    );
+if (!applicationId) throw new Error("Please make sure the bot's application ID is mentioned on \"APPLICATIONID\"");
 if (!token) throw new Error("Please make sure you add a token");
 if (["GUILD", "RESET_GUILD"].includes(registerMode) && !guildId)
     throw new Error("The target's guild id is needed but was not provided");
@@ -31,18 +28,14 @@ const rest = new REST({ version: "9" }).setToken(token);
 (async function () {
     for (const file of commandFiles) {
         const { default: command } = await import(`${file}`);
-        commands.push(command.data.toJSON());
+        commands.push(command.slashCommand.data.toJSON());
     }
     console.info(
         `${
-            ["RESET_GUILD", "RESET_GLOBAL"].includes(registerMode)
-                ? "Resetting"
-                : "Reloading"
+            ["RESET_GUILD", "RESET_GLOBAL"].includes(registerMode) ? "Resetting" : "Reloading"
         } application (/) commands for ${applicationId} ${
-            ["GUILD", "RESET_GUILD"].includes(registerMode)  ? `on guild ${guildId}` : ""
-        }: \n\t${commands
-            .map((cmd) => cmd.name)
-            .join("\n\t")}\nOn mode: "${registerMode}"`
+            ["GUILD", "RESET_GUILD"].includes(registerMode) ? `on guild ${guildId}` : ""
+        }: \n\t${commands.map((cmd) => cmd.name).join("\n\t")}\nOn mode: "${registerMode}"`,
     );
     try {
         if (registerMode === "RESET_GUILD") {
@@ -65,10 +58,8 @@ const rest = new REST({ version: "9" }).setToken(token);
 
         console.info(
             `Successfully ${
-                ["RESET_GUILD", "RESET_GLOBAL"].includes(registerMode)
-                    ? "reset"
-                    : "reloaded"
-            } application (/) commands.`
+                ["RESET_GUILD", "RESET_GLOBAL"].includes(registerMode) ? "reset" : "reloaded"
+            } application (/) commands.`,
         );
     } catch (error) {
         console.error(error);

--- a/src/interfaces.ts
+++ b/src/interfaces.ts
@@ -3,28 +3,85 @@ import type {
     CommandInteraction,
     Collection,
     PermissionString,
+    ButtonInteraction,
+    SelectMenuInteraction,
+    AutocompleteInteraction,
+    ApplicationCommandOptionChoice,
 } from "discord.js";
-import type {
-    SlashCommandBuilder,
-    SlashCommandSubcommandsOnlyBuilder,
-} from "@discordjs/builders";
-type SlashCommandOptionsType = ReturnType<
-  SlashCommandBuilder["addChannelOption"]
->;
+import type { SlashCommandBuilder, SlashCommandSubcommandsOnlyBuilder } from "@discordjs/builders";
+type SlashCommandOptionsType = ReturnType<SlashCommandBuilder["addChannelOption"]>;
 export interface MyContext {
-  client: Client;
-  commands: Collection<string, Command>;
-  cooldownCounter: Collection<string, number>;
+    client: Client;
+    commands: {
+        autocompletes: Collection<string, Command["autocomplete"][number]>;
+        buttons: Collection<string, Command["buttons"][number]>;
+        selectMenus: Collection<string, Command["selectMenus"][number]>;
+        slashCommands: Collection<string, Command["slashCommand"]>;
+    };
+    cooldownCounter: Collection<string, number>;
 }
 export interface Command {
-  data:
-    | SlashCommandBuilder
-    | SlashCommandSubcommandsOnlyBuilder
-    | SlashCommandOptionsType;
-  cooldown?: number;
-  // * Note that as of writing, slash commands can override permissions
-  botPermissions?: PermissionString[];
-  authorPermissions?: PermissionString[];
-  guildOnly?: boolean;
-  execute(interaction: CommandInteraction, context: MyContext): Promise<void>;
+    slashCommand?: {
+        data: SlashCommandBuilder | SlashCommandSubcommandsOnlyBuilder | SlashCommandOptionsType;
+        cooldown?: number;
+        // * Note that as of writing, slash commands use the permissions for @everyone
+        botPermissions?: PermissionString[];
+        authorPermissions?: PermissionString[];
+        guildOnly?: boolean;
+        run(interaction: CommandInteraction, context: MyContext): Promise<void>;
+    };
+    buttons?: { custom_id: string; run(interaction: ButtonInteraction<"cached">, context: MyContext): Promise<void> }[];
+    selectMenus?: {
+        custom_id: string;
+        run(interaction: SelectMenuInteraction<"cached">, context: MyContext): Promise<void>;
+    }[];
+    autocomplete?: {
+        focusedOption: string;
+        run(
+            interaction: AutocompleteInteraction<"cached">,
+            focusedOption: ApplicationCommandOptionChoice,
+            context: MyContext,
+        ): Promise<void>;
+    }[];
+}
+export interface MdnDoc {
+    isMarkdown: boolean;
+    isTranslated: boolean;
+    isActive: boolean;
+    flaws: Record<string, unknown>;
+    title: string;
+    mdn_url: string;
+    locale: string;
+    native: string;
+    sidebarHTML: string;
+    body: {
+        type: "prose" | "specifications" | "browser_compatibility";
+        value: {
+            id: string | null;
+            title: string | null;
+            isH3: boolean;
+            // type:prose
+            content?: string;
+            // type:specifications
+            specifications?: { bcdSpecificationURL: string; title: string; shortTitle: string }[];
+            // type:browser_compatibility
+            dataURL?: string;
+            // type:specifications | type:browser_compatibility
+            query?: string;
+        };
+    }[];
+    toc: { text: string; id: string }[];
+    summary: string;
+    popularity: number;
+    modified: string; // ISO Date String
+    other_translations: { title: string; locale: string; native: string }[];
+    source: {
+        folder: string;
+        github_url: string;
+        last_commit_url: string;
+        filename: string;
+    };
+    parents: { uri: string; title: string }[];
+    pageTitle: string;
+    noIndexing: boolean;
 }

--- a/src/utils/CommandUtils.ts
+++ b/src/utils/CommandUtils.ts
@@ -1,5 +1,5 @@
 import { Permissions, Formatters, MessageButton } from "discord.js";
-import type { CommandInteraction, Snowflake } from "discord.js";
+import type { CommandInteraction, Snowflake, ButtonInteraction, Message } from "discord.js";
 import type { Command, MyContext } from "../interfaces";
 
 export const deleteButton = (initiatorId: Snowflake) =>
@@ -8,6 +8,19 @@ export const deleteButton = (initiatorId: Snowflake) =>
         .setEmoji("🗑")
         .setStyle("SECONDARY");
 
+export const deleteButtonHandler = async (interaction: ButtonInteraction<"cached">) => {
+    const commandInitiatorId = interaction.customId.replace("deletebtn/", "");
+    // If the button clicker is the command initiator
+    if (interaction.user.id === commandInitiatorId) {
+        (interaction.message as Message).delete().catch(console.error);
+    } else
+        await interaction
+            .reply({
+                content: "Only the command initiator is allowed to delete this message",
+                ephemeral: true,
+            })
+            .catch(console.error);
+};
 /**
  * Checks if the bot or a user has the needed permissions to run a command
  * @param interaction
@@ -15,7 +28,7 @@ export const deleteButton = (initiatorId: Snowflake) =>
  * @returns Whether to cancel the command
  */
 // * Note that as of writing, slash commands can override permissions
-export function commandPermissionCheck(interaction: CommandInteraction, command: Command): boolean {
+export function commandPermissionCheck(interaction: CommandInteraction, command: Command["slashCommand"]): boolean {
     const { client, user, channel } = interaction;
     // If the channel is a dm
     // if it's a partial, channel.type wouldn't exist
@@ -61,7 +74,7 @@ export function commandPermissionCheck(interaction: CommandInteraction, command:
     // By default, allow execution;
     return false;
 }
-export function commandCooldownCheck(interaction: CommandInteraction, command: Command, context: MyContext): boolean {
+export function commandCooldownCheck(interaction: CommandInteraction, command: Command["slashCommand"], context: MyContext): boolean {
     const { user } = interaction;
     if (command.cooldown) {
         const id = user.id + "/" + interaction.commandName;


### PR DESCRIPTION
- Command structure has been refactored: now handlers for buttons, select-menus and autocompletes for a specific command should be placed inside the command file itself

- Now autocompletes and select-menus use _**25**_ options instead of 10 

- Fixed a bug with `/mdn` where exact matches weren't being displayed

- Added autocompletes for the other supported `/djs` sources by using the `source:query` format, example: `builders:slashcommandbuilder#addUserOption`
